### PR TITLE
Update 2018-03-27-weekly.md

### DIFF
--- a/_drafts/2018-03-27-weekly.md
+++ b/_drafts/2018-03-27-weekly.md
@@ -12,6 +12,10 @@ Feature story text here
 * [HACKSPACE #5 is here - with ADAFRUIT!](https://hackspace.raspberrypi.org/issues/5)
 * [NumPy calculator controls MicroPython-powered robot](https://youtu.be/Az5W-PsQP64)
 * [USB Foot Switch built with CircuitPython](https://learn.adafruit.com/USB-foot-switch-circuit-python)
+* [We have a post on how to contribute to this newsletter too] (https://blog.adafruit.com/2018/03/22/contribute-to-the-circuitpython-weekly-newsletter-adafruit-on-github-circuitpython/)
+
+# Upcoming events!
+May 2018 - [The PyCon 2018 conference] (https://us.pycon.org/2018/about/), which will take place in Cleveland, is the largest annual gathering for the community using and developing the open-source Python programming language. It is produced and underwritten by the Python Software Foundation, the 501(c)(3) nonprofit organization dedicated to advancing and promoting Python. Through PyCon, the PSF advances its mission of growing the international community of Python programmers. Adafruit is a sponsor, we'll see you in the goodie bag :)
 
 ## Latest releases
 


### PR DESCRIPTION
added * [We have a post on how to contribute to this newsletter too] (https://blog.adafruit.com/2018/03/22/contribute-to-the-circuitpython-weekly-newsletter-adafruit-on-github-circuitpython/)

and 

+# Upcoming events!
+May 2018 - [The PyCon 2018 conference] (https://us.pycon.org/2018/about/), which will take place in Cleveland, is the largest annual gathering for the community using and developing the open-source Python programming language. It is produced and underwritten by the Python Software Foundation, the 501(c)(3) nonprofit organization dedicated to advancing and promoting Python. Through PyCon, the PSF advances its mission of growing the international community of Python programmers. Adafruit is a sponsor, we'll see you in the goodie bag :)