### PR TITLE
Update 2018-03-27-weekly.md

### DIFF
--- a/_drafts/2018-03-27-weekly.md
+++ b/_drafts/2018-03-27-weekly.md
@@ -5,7 +5,29 @@ date: 2018-03-27 07:00:00 -0800
 categories: weekly
 ---
 
-Feature story text here
+@ntoll visits Adafruit and talks with Ladyada about all things Python, education, communities, and the Mu editor.
+
+IMAGE?
+
+[Video](https://youtu.be/L1wYvTRzM2c)
+
+Mu is a simple code editor for beginner programmers based on the feedback given to and experiences of the Raspberry Pi Foundation's education team. Having said that, Mu is for anyone who wants to use a simple "no frills" editor.
+
+Mu is a modal editor with modes for Adafruit's CircuitPython, the micro:bit's version of MicroPython and standard Python 3 (including a graphical debugger). All modes make available a REPL (either running on the connected CircuitPython or MicroPython device or as a Jupyter based iPython session in Python3 mode).
+
+It's written in Python and works on Windows, OSX, Linux and Raspberry Pi.
+
+Nicholas Tollervey is a classically trained musician, philosophy graduate, teacher, writer and software developer. Nicholas has been programming since 1984 when he taught himyself using his school's BBC B. He's been online since 1994 and made software development [his career in 2002](http://ntoll.org/about/) & is a [Python fellow](https://www.python.org/psf/).
+
+Mu is a simple code editor for beginner programmers. It's written in Python and works on Windows, OSX, Linux and Raspberry Pi.
+
+[Code With Mu](https://codewith.mu/)
+
+[mu-editor/mu (GitHub)](https://github.com/mu-editor/mu)
+
+[Personal site](http://ntoll.org/)
+
+[Twitter](https://twitter.com/ntoll/)
 
 # News from around the web!
 * [Implementing MicroPython as a UEFI Test Framework](https://software.intel.com/en-us/blogs/2018/03/08/implementing-micropython-as-a-uefi-test-framework)


### PR DESCRIPTION
added


@ntoll visits Adafruit and talks with Ladyada about all things Python, education, communities, and the Mu editor.

IMAGE?

[Video](https://youtu.be/L1wYvTRzM2c)

Mu is a simple code editor for beginner programmers based on the feedback given to and experiences of the Raspberry Pi Foundation's education team. Having said that, Mu is for anyone who wants to use a simple "no frills" editor.

Mu is a modal editor with modes for Adafruit's CircuitPython, the micro:bit's version of MicroPython and standard Python 3 (including a graphical debugger). All modes make available a REPL (either running on the connected CircuitPython or MicroPython device or as a Jupyter based iPython session in Python3 mode).

It's written in Python and works on Windows, OSX, Linux and Raspberry Pi.

Nicholas Tollervey is a classically trained musician, philosophy graduate, teacher, writer and software developer. Nicholas has been programming since 1984 when he taught himyself using his school's BBC B. He's been online since 1994 and made software development [his career in 2002](http://ntoll.org/about/) & is a [Python fellow](https://www.python.org/psf/).

Mu is a simple code editor for beginner programmers. It's written in Python and works on Windows, OSX, Linux and Raspberry Pi.

[Code With Mu](https://codewith.mu/)

[mu-editor/mu (GitHub)](https://github.com/mu-editor/mu)

[Personal site](http://ntoll.org/)

[Twitter](https://twitter.com/ntoll/)
