### PR TITLE
Update 2018-04-02-weekly.md

### DIFF
--- a/_drafts/2018-04-02-weekly.md
+++ b/_drafts/2018-04-02-weekly.md
@@ -17,6 +17,8 @@ Feature story text here
 
 [See the spectrum with our new CircuitPython Driver for the Adafruit AS7262 spectral sensor](https://learn.adafruit.com/adafruit-as7262-6-channel-visible-light-sensor/circuitpython-wiring-test)
 
+[CircuitPython Snakes its Way onto Adafruit Hardware](https://makezine.com/2017/08/11/circuitpython-snakes-way-adafruit-hardware/)
+
 # Upcoming events!
 May 2018 - [The PyCon 2018 conference](https://us.pycon.org/2018/about/), which will take place in Cleveland, is the largest annual gathering for the community using and developing the open-source Python programming language. It is produced and underwritten by the Python Software Foundation, the 501(c)(3) nonprofit organization dedicated to advancing and promoting Python. Through PyCon, the PSF advances its mission of growing the international community of Python programmers. Adafruit is a sponsor, we'll see you in the goodie bag :)
 


### PR DESCRIPTION
added reference article - [CircuitPython Snakes its Way onto Adafruit Hardware](https://makezine.com/2017/08/11/circuitpython-snakes-way-adafruit-hardware/)