### PR TITLE
Add PyCon AU details

### DIFF
--- a/_drafts/2019-08-13-draft.md
+++ b/_drafts/2019-08-13-draft.md
@@ -114,6 +114,32 @@ And check out [AWESOME-FEATHER](https://github.com/adafruit/awesome-feather), a 
 
 Cardboard shoulder mounted wing - [Twitter](https://twitter.com/sophywong/status/1159916643826294784).
 
+## PyCon AU
+
+_THE_ Australian event for all things Python, PyCon AU 2019 was a huge success with many diverse and high-quality talks that covered the gamut of Python topics. MicroPython and CircuitPython were _very_ well represented with six talks covering Python on Hardware.
+
+All of the 80+ talks were recorded and published on YouTube - take a look at the [PyCon AU 2019 playlist](https://www.youtube.com/playlist?list=PLs4CJRBY5F1LKqauI3V4E_xflt6Gow611) or [browse the schedule](https://2019.pycon-au.org/schedule/friday/). 
+
+MicroPython Sprints were organised for the Monday and Tuesday and these were well attended with some productive work achieved! Beginners to MicroPython (like [Leo](https://tumblelog.halloleo.net/post/186930271429/i-built-my-first-microcontroller-thing)) were warmly introduced, Damien guided folks to work on a spate of issues, two variants of a C stub generator ([uStubby](https://github.com/pazzarpj/micropython-ustubby) and [MicroPython C Stub Gen](https://gitlab.com/oliver.robson/mpy-c-stub-gen)) were worked on, the [QR Displayer](https://gitlab.com/oliver.robson/micropython-qr-displayer) project was released, a [CI server](https://gitlab.com/alelec/micropython_ci/) was configured to build _all_ (nearly 100!) the officially supported MicroPython variants and ♥️ was expressed with a [micro:bit](https://twitter.com/weatheredpup/status/1158705177613836288)! There was also collaboration with the [Fomu project](https://www.crowdsupply.com/sutajio-kosagi/fomu) and a port of MicroPython was built to run on the RISC-V softcore running on the Fomu FPGA - that lives _inside_ a USB port!
+
+Continue the discussion on the [MicroPython Slack workspace](https://slack-micropython.herokuapp.com/)!
+
+[![Goodbye Print Statements, Hello Debugger](../assets/08132019/81319prints.jpg)](https://youtu.be/HHrVBKZLolg)
+
+["Goodbye Print Statements, Hello Debugger!"](https://2019.pycon-au.org/talks/goodbye-print-statements-hello-debugger) - Nina Zakharenko. Still debugging your code with print statements? Learn how to level up your ability to troubleshoot complex code situations by using the power of a fully-featured debugger in this talk aimed at all levels of programming ability - [YouTube](https://youtu.be/HHrVBKZLolg).
+
+["What makes Micro:bits different?"](https://2019.pycon-au.org/talks/what-makes-microbits-different) - Jack Reichelt. There’s many different ways to learn to code, and how you start your students’ journey changes what challenges they’ll face.This talk will highlight some of the differences when using Micro:bits, and how to overcome the challenges. [YouTube](https://youtu.be/ZEg0cLKwzF4)
+
+["Using comedy as an excuse to play with python-programmed microcontrollers"](https://2019.pycon-au.org/talks/using-comedy-as-an-excuse-to-play-with-python-programmed-microcontrollers) - Anthony I. Joseph and Debbie Zukerman. Early-career comedians often have difficulties adding electronic props to their acts, due to the high cost of materials and fabrication skills required. This talk will recreate several props used in comedic performances, showing the code and components used. [YouTube](https://youtu.be/6Rv7S_74fck)
+
+["Profiling Pathogens with (micro) Python"](https://2019.pycon-au.org/talks/profiling-athogens-with-micro-python) - Andrew Leech. We’re building professional medical diagnostics equipment with MicroPython. This has come with minimal challenges, many positives and a few surprises! [YouTube](https://youtu.be/YovngSLXoxw)
+
+["It's dark and my lights aren't working (an asyncio success story)"](https://2019.pycon-au.org/talks/its-dark-and-my-lights-arent-working-an-asyncio-success-story) - Jim Mussared. I have invested huge amounts of time in achieving a simple goal – making the lighting in my home “smart”. It’s not ground breaking, nor is it practical or cost effective, but it sure was educational, uses a bunch of Python, and the result makes me (and my family) happy. [YouTube](https://youtu.be/grouP9QfdyA)
+
+["Extending MicroPython: Using C for good!"](https://2019.pycon-au.org/talks/extending-micropython-using-c-for-good) - Matt Trentini. MicroPython is a _fantastic_ environment for embedded development. But it is an interpreted language; what happens when you hit performance limitations? Or want to use a new feature of your microcontroller? We’ll look at how MicroPython can be _extended_ to add features and improve performance. [YouTube](https://youtu.be/fUb3Urw4H-E)
+
+["Micropython Gotchas"](https://2019.pycon-au.org/talks/micropython-gotchas) - Michał Gałka. We all somehow get the feeling that MicroPython is not quite the Python we know. During the talk, I’ll show what the “not quite” actually means. I’ll present a set of different issues I stumbled upon when working with different MicroPython powered boards ranging from memory constraints to API calls. [YouTube](https://youtu.be/93ed-YyOWkc)
+
 ## News from around the web!
 
 [![CircuitPython powered Automatic Fume Extractor](../assets/08132019/81319fumes.jpg)](https://hackaday.io/project/166813-automatic-fume-extractor)
@@ -157,10 +183,6 @@ WebUSB demo! NeoPixel Color picker for Circuit Playground Express - [YouTube](ht
 Say “Hello” to the OrangeCrab - [hackster.io](https://blog.hackster.io/say-hello-to-the-orangecrab-16835001f36a)
 
 Giant Board, Using the Wi-Fi FeatherWing - [Crowd Supply](https://www.crowdsupply.com/groboards/giant-board/updates/using-the-wi-fi-featherwing).
-
-[![Goodbye Print Statements, Hello Debugger](../assets/08132019/81319prints.jpg)](https://youtu.be/HHrVBKZLolg)
-
-["Goodbye Print Statements, Hello Debugger!"](https://2019.pycon-au.org/talks/goodbye-print-statements-hello-debugger) - Nina Zakharenko, PyCon AU 2019. Still debugging your code with print statements? Learn how to level up your ability to troubleshoot complex code situations by using the power of a fully-featured debugger in this talk aimed at all levels of programming ability - [YouTube](https://youtu.be/HHrVBKZLolg).
 
 Python in Visual Studio Code – August 2019 Release - [Microsoft](https://devblogs.microsoft.com/python/python-in-visual-studio-code-august-2019-release/).
 


### PR DESCRIPTION
I've added a brief summary of PyCon AU, particularly where it involved MicroPython/CircuitPython. Also added links to all the talks that covered our favorite embedded languages.
Nina's talk is now a little different to the others since it didn't actually cover MicroPython or CircuitPython so this may be a little confusing - but it was a great talk so let's just gloss over that fact!