### PR TITLE
cyberDÛCK

### DIFF
--- a/_drafts/2020-05-12-draft.md
+++ b/_drafts/2020-05-12-draft.md
@@ -45,6 +45,14 @@ Adafruit has always been an open source hardware company, predating the [Open So
 
 ## News from around the web!
 
+[![cyberDÛCK](../assets/20200512/cyberDuck portrait.jpg)](https://hackaday.io/project/171269-cyberdck-a-circuitpython-anatidae)
+
+disaster recover  "cyberdeck" + duck = cyberDÛCK
+
+With this duck you can hookup a USB keyboard to your CircuitPython device, edit python text files and run it right on the same machine.  And it's water resistant, everything you'd expect in a cyberDÛCK. 
+
+Includes a USB Host Controller (ItsyBitsy M4) using UART to the main controller (ItsyBitsy M4), a UART-controlled REPL and a text editor.  Now you can get coding directly on a portable bird and fly wherever you want!
+
 [![title](../assets/20200mdd/20200mdd-name.jpg)](https://circuitpython.org/)
 
 Text


### PR DESCRIPTION
disaster recover "cyberdeck" computer + CircuitPython duck = cyberDÛCK

Standalone CircuitPython computer with USB host for keyboard input, a REPL over UART and a text editor.  And weather resistant too, like all good ducks.  

Program and run some code on the fly!  If only there was a Blinka with a duck bill saying "Quack!"

Uses two ItsyBitsy M4s, a 240x240 TFT SPI display, USB on-the-go cable (OTG) and a USB keyboard.