### PR TITLE
Add link to Woolsey Workshop tutorial

### DIFF
--- a/_drafts/2020-10-05-draft.md
+++ b/_drafts/2020-10-05-draft.md
@@ -58,6 +58,8 @@ Science is fun and educational when using Adafruit parts and free, easy to follo
 
 [![title](../assets/20201005/20201005-name.jpg)](https://circuitpython.org/)
 
+Woolsey Workshop published a tutorial on how to get started using Blinka to support your CircuitPrograms on the Raspberry Pi. - [Woolsey Workshop](https://www.woolseyworkshop.com/2020/09/29/getting-started-with-circuitpython-on-raspberry-pi-with-blinka/) and [Twitter](https://twitter.com/JohnWWoolsey/status/1310969536221523969).
+
 Text
 
 ## Coming soon


### PR DESCRIPTION
Add a link to Woolsey Workshop's Getting Started With CircuitPython On Raspberry Pi With Blinka tutorial.