### PR TITLE
updated details for NAU7802 FeatherWing and library

### DIFF
--- a/_drafts/2020-12-01-draft.md
+++ b/_drafts/2020-12-01-draft.md
@@ -47,11 +47,11 @@ If you are looking for a similar concept framework for microcontrollers, see cir
 
 ## Developing the NAU7802 24-bit DAC FeatherWing
 
-[![NAU7802 24-bit DAC FeatherWing](../assets/20201201/20201201cedar1.jpg)](https://twitter.com/CedarGroveMakr/status/1333156977174691840)
+[![NAU7802 24-bit ADC FeatherWing](../assets/20201201/20201201cedar1.jpg)](https://twitter.com/CedarGroveMakr/status/1333156977174691840)
 
-[![NAU7802 24-bit DAC FeatherWing CLUE Display](../assets/20201201/20201201cedar2.jpg)](https://twitter.com/CedarGroveMakr/status/1333156977174691840)
+[![NAU7802 24-bit ADC FeatherWing CLUE Display](../assets/20201201/20201201cedar2.jpg)](https://twitter.com/CedarGroveMakr/status/1333156977174691840)
 
-Testing with a custom NAU7802 FeatherWing. Being developed in CircuitPython, it measures load cells connected to a SparkFun Quiic scale breakout at present - [Twitter](https://twitter.com/CedarGroveMakr/status/1333156977174691840).
+Testing with a custom NAU7802 24-bit ADC FeatherWing and Stemma-QT connected Clue. Using a device library developed in CircuitPython, it measures up to two load cells connected to the custom FeatherWing. - [Twitter](https://twitter.com/CedarGroveMakr/status/1333156977174691840).
 
 > Developing a CircuitPython 6.0.0 library for the NAU7802 24-bit ADC FeatherWing was a worthwhile educational experience.
 


### PR DESCRIPTION
The project graduated beyond the temporary use of the single-channel Sparkfun Quiic Scale to use the dual-channel capability of the NAU7802 FeatherWing. The custom PCB was designed to work as a Wing connected to a Feather MCU or in a stand-alone mode via the on-board Stemma-QT connector.