### PR TITLE
New/updated libs/guides, stars

### DIFF
--- a/_drafts/2021-02-02-draft.md
+++ b/_drafts/2021-02-02-draft.md
@@ -5,7 +5,7 @@ date: 2021-02-02 07:00:00 -0800
 categories: weekly
 ---
 
-- [ ] Kattni updates
+- [X] Kattni updates
 - [ ] change date
 - [ ] update title
 - [ ] Feature story
@@ -104,15 +104,11 @@ Looking to add a new board to CircuitPython? It's highly encouraged! Adafruit ha
 
 [![New Learn Guides](../assets/2021mmdd/2021mmddlearn.jpg)](https://learn.adafruit.com/guides/latest)
 
-[title](url) from [name](url)
+[Raspberry Pi YouTube Boombox](https://learn.adafruit.com/youtube-radio) from [Noe and Pedro](https://learn.adafruit.com/users/pixil3d)
 
-[title](url) from [name](url)
+[Adafruit Feather M4 CAN Express](https://learn.adafruit.com/adafruit-feather-m4-can-express) from [Kattni](https://learn.adafruit.com/users/kattni)
 
-[title](url) from [name](url)
-
-## Updated Learn Guides!
-
-[title](url) from [name](url)
+[Neopixel Crystal Chandelier with CircuitPython Animations and Speed Control](https://learn.adafruit.com/neopixel-crystal-chandelier-with-circuitpython-animations-and-speed-control) from [Erin St. Blaine](https://learn.adafruit.com/users/firepixie)
 
 ## CircuitPython Libraries!
 
@@ -126,19 +122,20 @@ If you'd like to contribute, CircuitPython libraries are a great place to start.
 
 You can check out this [list of all the Adafruit CircuitPython libraries and drivers available](https://github.com/adafruit/Adafruit_CircuitPython_Bundle/blob/master/circuitpython_library_list.md). 
 
-The current number of CircuitPython libraries is **###**!
+The current number of CircuitPython libraries is **290**!
 
 **New Libraries!**
 
 Here's this week's new CircuitPython libraries:
 
-* [library](url)
+ * [Adafruit_CircuitPython_PIOASM](https://github.com/adafruit/Adafruit_CircuitPython_PIOASM)
+ * [Adafruit_CircuitPython_AW9523](https://github.com/adafruit/Adafruit_CircuitPython_AW9523)
 
 **Updated Libraries!**
 
 Here's this week's updated CircuitPython libraries:
 
-* [library](url)
+* A list of updated libraries can be found [here](https://adafruit-circuit-python.s3.amazonaws.com/adabot/bin/reports/circuitpython_library_report_20210127.txt).
 
 ## What’s the team up to this week?
 
@@ -222,7 +219,7 @@ CircuitPython's stable release is [#.#.#](https://github.com/adafruit/circuitpyt
 
 [#.#.#](https://www.python.org/downloads/) is the latest Python release. The latest pre-release version is [#.#.#](https://www.python.org/download/pre-releases/).
 
-[#### Stars](https://github.com/adafruit/circuitpython/stargazers) Like CircuitPython? [Star it on GitHub!](https://github.com/adafruit/circuitpython)
+[2217 Stars](https://github.com/adafruit/circuitpython/stargazers) Like CircuitPython? [Star it on GitHub!](https://github.com/adafruit/circuitpython)
 
 ## Call for help -- Translating CircuitPython is now easier than ever!
 


### PR DESCRIPTION
Updated library list is really long because of the CI updates release sweep, so I linked to the CP/Libs report on S3 instead of doubling the length of the newsletter.