### PR TITLE
Remove guide link from status

### DIFF
--- a/_drafts/2021-04-20-draft.md
+++ b/_drafts/2021-04-20-draft.md
@@ -439,7 +439,7 @@ I've also been monitoring the existing power PRs to try and make sure they all s
 
 This past week, I've been working on the FunHouse. First I wrote the FunHouse library, which is similar to the MagTag library, but with different peripherals and MQTT functionality. The library is available either in the [Adafruit CircuitPython Bundle](https://github.com/adafruit/Adafruit_CircuitPython_Bundle/releases) or from https://github.com/adafruit/Adafruit_CircuitPython_FunHouse.
 
-Once the library was complete, I wrote a guide on using the Funhouse board with home assistant. In the guide, I go over setting up the FunHouse project as well as how to do some more advanced things such as mapping the buttons to toggle lights and emulating an RGB bulb with the DotStars so it can be controlled from Home Assistant like any other light. You can check out the guide at https://learn.adafruit.com/using-the-adafruit-funhouse-with-home-assistant.
+Once the library was complete, I wrote a guide on using the Funhouse board with home assistant. In the guide, I go over setting up the FunHouse project as well as how to do some more advanced things such as mapping the buttons to toggle lights and emulating an RGB bulb with the DotStars so it can be controlled from Home Assistant like any other light. Keep an eye out for the upcoming guide.
 
 **Scott**
 


### PR DESCRIPTION
Since it looks like guide may not be published before newsletter goes out, I removed the link.