### PR TITLE
fix Python Bytes name and add link + info about deep dive

### DIFF
--- a/_drafts/2022-03-15-draft.md
+++ b/_drafts/2022-03-15-draft.md
@@ -69,7 +69,7 @@ The Pi Cast (3/15/22): The CircuitPython Show with Paul Cutler - [YouTube](https
 
 [![Anne Barela on the Python Bytes Stream](../assets/20220315/20220315pb.jpg)](https://pythonbytes.fm/episodes/show/274/12-questions-you-should-be-asking-of-your-dependencies)
 
-Bython Bytes Episode #274: 12 Questions You Should Be Asking of Your Dependencies features CircuitPython team member Anne Barela (*note: Anne is edtor of this newsletter*). Discussions of this newsletter, CircuitPython, MicroPython, and GitHub in addition to some other wonderful Python topics - [Python Bytes](https://pythonbytes.fm/episodes/show/274/12-questions-you-should-be-asking-of-your-dependencies) and [YouTube](https://www.youtube.com/watch?v=32XHiEhEDkU).
+Python Bytes Episode #274: 12 Questions You Should Be Asking of Your Dependencies features CircuitPython team member Anne Barela (*note: Anne is edtor of this newsletter*). Discussions of this newsletter, CircuitPython, MicroPython, and GitHub in addition to some other wonderful Python topics - [Python Bytes](https://pythonbytes.fm/episodes/show/274/12-questions-you-should-be-asking-of-your-dependencies) and [YouTube](https://www.youtube.com/watch?v=32XHiEhEDkU).
 
 ## This Week's Python Streams
 
@@ -77,7 +77,7 @@ Bython Bytes Episode #274: 12 Questions You Should Be Asking of Your Dependencie
 
 [![Deep Dive](../assets/20220315/20220315deepdive.jpg)](link)
 
-[This week](link), Tim streams  work on .
+[This week](https://www.youtube.com/watch?v=ivXl4rlNe8k), Tim streams work on experimenting with async displayio.
 
 You can see the latest video and past videos on the Adafruit YouTube channel under the Deep Dive playlist - [YouTube](https://www.youtube.com/playlist?list=PLjF7R1fz_OOXBHlu9msoXq2jQN4JpCk8A).
 


### PR DESCRIPTION
I noticed a small typo in Python Bytes podcast name, fixed with this PR.

Also added a link and a bit of info about the deep dive from this week.