### PR TITLE
adding post meeting changes for 5-16-22 meeting. Add one missing YT link

### DIFF
--- a/_drafts/2022-05-17-draft.md
+++ b/_drafts/2022-05-17-draft.md
@@ -155,7 +155,7 @@ Two GC9A01 round TFT LCDs being driven by CircuitPython on a Raspberry Pi Pico, 
 
 [![Smart Cooler Monitor](../assets/20220517/20220517cpx.jpg)](https://youtu.be/VdQneHcn8wU)
 
-Building a Smart Cooler Monitor Using Circuit Playground Express and CircuitPython - [Adafruit Blog](https://blog.adafruit.com/2022/05/16/smart-cooler-monitor-using-circuit-playground-express/) and [YouTube]().
+Building a Smart Cooler Monitor Using Circuit Playground Express and CircuitPython - [Adafruit Blog](https://blog.adafruit.com/2022/05/16/smart-cooler-monitor-using-circuit-playground-express/) and [YouTube](https://youtu.be/VdQneHcn8wU).
 
 [![Pico](../assets/20220517/20220517btn.gif)](https://www.reddit.com/r/circuitpython/comments/unncb8/ive_been_playing_with_an_74hc595_need_to_get_a/)
 
@@ -193,9 +193,9 @@ The Linux Foundation Initiates "World of Open Source" Research Series - [PR News
 
 Free training course - Ethics for Open Source Development - [Linux Foundation](https://training.linuxfoundation.org/training/ethics-for-open-source-development-lfc104/).
 
-PyDev of the Week:
+PyDev of the Week: Raza (Rython) Zaidi on [Mouse vs Python](https://www.blog.pythonlibrary.org/2022/05/16/pydev-of-the-week-raza-rython-zaidi/)
 
-CircuitPython Weekly Meeting for 
+CircuitPython Weekly Meeting for May 16, 2022 ([notes](https://github.com/adafruit/adafruit-circuitpython-weekly-meeting/blob/main/2022/2022-05-16.md)) [on YouTube](https://youtu.be/lvgmQF7CNo4)
 
 #ICYDNCI What was the most popular, most clicked link, in [last week's newsletter](https://www.adafruitdaily.com/2022/05/10/python-on-microcontrollers-newsletter-python-still-at-1-risc-v-seeks-world-domination-and-more-python-circuitpython-micropython-thepsf/)? [Chip Shortage: ST STM32F405](https://blog.adafruit.com/2022/05/05/chip-shortage-st-stm32f405-chipshortage-adafruit-adafruit-st_world-micropython/).
 
@@ -346,15 +346,15 @@ As for other events, with the COVID pandemic, most in-person events are postpone
 
 ## Latest releases
 
-CircuitPython's stable release is [#.#.#](https://github.com/adafruit/circuitpython/releases/latest) and its unstable release is [#.#.#-##.#](https://github.com/adafruit/circuitpython/releases). New to CircuitPython? Start with our [Welcome to CircuitPython Guide](https://learn.adafruit.com/welcome-to-circuitpython).
+CircuitPython's stable release is [7.2.5](https://github.com/adafruit/circuitpython/releases/latest) and its unstable release is [7.3.0-rc.0](https://github.com/adafruit/circuitpython/releases). New to CircuitPython? Start with our [Welcome to CircuitPython Guide](https://learn.adafruit.com/welcome-to-circuitpython).
 
-[2022####](https://github.com/adafruit/Adafruit_CircuitPython_Bundle/releases/latest) is the latest CircuitPython library bundle.
+[20220515](https://github.com/adafruit/Adafruit_CircuitPython_Bundle/releases/latest) is the latest CircuitPython library bundle.
 
-[v#.#.#](https://micropython.org/download) is the latest MicroPython release. Documentation for it is [here](http://docs.micropython.org/en/latest/pyboard/).
+[v1.18](https://micropython.org/download) is the latest MicroPython release. Documentation for it is [here](http://docs.micropython.org/en/latest/pyboard/).
 
-[#.#.#](https://www.python.org/downloads/) is the latest Python release. The latest pre-release version is [#.#.#](https://www.python.org/download/pre-releases/).
+[3.10.4](https://www.python.org/downloads/) is the latest Python release. The latest pre-release version is [3.11.0b1](https://www.python.org/download/pre-releases/).
 
-[#,### Stars](https://github.com/adafruit/circuitpython/stargazers) Like CircuitPython? [Star it on GitHub!](https://github.com/adafruit/circuitpython)
+[2972 Stars](https://github.com/adafruit/circuitpython/stargazers) Like CircuitPython? [Star it on GitHub!](https://github.com/adafruit/circuitpython)
 
 ## Call for help -- Translating CircuitPython is now easier than ever!
 


### PR DESCRIPTION
I Noticed the smart cooler news item didn't have it's Youtube link filled in to the text line and added that along with the normal post meeting changes.