### PR TITLE
Fix two typos in newsletter

### DIFF
--- a/_drafts/2022-10-18-draft.md
+++ b/_drafts/2022-10-18-draft.md
@@ -33,7 +33,7 @@ We're on [Discord](https://discord.gg/HYqvREz), [Twitter](https://twitter.com/se
 
 [![Espressif DevCon22](../assets/20221018/20221018esp.jpg)](https://devcon.espressif.com/#program)
 
-Espressif DevCon22 is the first official for Espressif developers. This two-day online conference October 19-20 will bring to you content about products and solutions created by Espressif and its partners. You can expect over 30 talks on topics including Matter, RainMaker, ESP-IDF, Privilege Separation, Embedded Rust, Components Manager, Board Support Packages, 3rd-party frameworks, and more - [Espressif](https://devcon.espressif.com/#program).
+Espressif DevCon22 is the first official conference for Espressif developers. This two-day online conference October 19-20 will bring to you content about products and solutions created by Espressif and its partners. You can expect over 30 talks on topics including Matter, RainMaker, ESP-IDF, Privilege Separation, Embedded Rust, Components Manager, Board Support Packages, 3rd-party frameworks, and more - [Espressif](https://devcon.espressif.com/#program).
 
 [![Espressif DevCon22 - Ladyada](../assets/20221018/20221018esp2.jpg)](https://devcon.espressif.com/#program)
 
@@ -135,7 +135,7 @@ The latest episode was released October 17th and features Jim Mussared, a MicroP
 
 [![HP 16C Calculator](../assets/20221018/20221018hp.jpg)](https://www.reddit.com/r/circuitpython/comments/y2b995/my_homerolled_hp_16c_implemention_work_in_progress/)
 
-A homerolled HP 16C implemention (work in progress) by u/someyob - [Reddit](https://www.reddit.com/r/circuitpython/comments/y2b995/my_homerolled_hp_16c_implemention_work_in_progress/).
+A homerolled HP 16C implementation (work in progress) by u/someyob - [Reddit](https://www.reddit.com/r/circuitpython/comments/y2b995/my_homerolled_hp_16c_implemention_work_in_progress/).
 
 > A work in progress, including labels for the missing keys. Does its thing in RPN, of course. Right now, base conversion. Raspberry Pi Pico, 1602 LCD with level shifters, aliexpress keypads with rows wired together to create a 40-key keypad. Learning Python along the way with Adafruit's Circuitpython.
 


### PR DESCRIPTION
Added missing word in Espressif section and fixed project of the week typo (implementation)