### PR TITLE
weekly meeting updates

### DIFF
--- a/_drafts/2022-10-25-draft.md
+++ b/_drafts/2022-10-25-draft.md
@@ -250,9 +250,9 @@ Sorting a Python Dictionary: Values, Keys, and more - [Real Python](https://real
 
 In preparation for the release of Python 3.11, [NumPy](https://numpy.org/) has gotten ahead of the pack and published [wheels](https://realpython.com/python-wheels/) for CPython 3.11. This is great news for a lot of other packages that depend on NumPy and wouldn’t be able to get started on porting to 3.11 without the a NumPy 3.11 wheel - [Real Python News](https://realpython.com/python-news-august-2022/).
 
-PyDev of the Week: NAME on [Mouse vs Python]()
+PyDev of the Week: Marin Kozak on [Mouse vs Python](https://www.blog.pythonlibrary.org/2022/10/24/pydev-of-the-week-marcin-kozak/)
 
-CircuitPython Weekly Meeting for DATE ([notes]()) [on YouTube]()
+CircuitPython Weekly Meeting for October 24, 2022 ([notes](https://github.com/adafruit/adafruit-circuitpython-weekly-meeting/blob/main/2022/2022-10-24.md)) [on YouTube](https://youtu.be/QrgwNvKBuvI)
 
 #ICYDNCI What was the most popular, most clicked link, in [last week's newsletter](https://www.adafruitdaily.com/2022/10/18/python-on-microcontrollers-newsletter-ladyada-at-espressif-devcon-this-week-circuitpython-8-beta-2-and-more-circuitpython-micropython-thepsf-raspberry_pi/)? [Espressif DevCon22](https://devcon.espressif.com/#program).
 
@@ -375,13 +375,13 @@ As for other events, with the COVID pandemic, most in-person events are postpone
 
 ## Latest releases
 
-CircuitPython's stable release is [#.#.#](https://github.com/adafruit/circuitpython/releases/latest) and its unstable release is [#.#.#-##.#](https://github.com/adafruit/circuitpython/releases). New to CircuitPython? Start with our [Welcome to CircuitPython Guide](https://learn.adafruit.com/welcome-to-circuitpython).
+CircuitPython's stable release is [7.3.3](https://github.com/adafruit/circuitpython/releases/latest) and its unstable release is [8.0.0-beta.3](https://github.com/adafruit/circuitpython/releases). New to CircuitPython? Start with our [Welcome to CircuitPython Guide](https://learn.adafruit.com/welcome-to-circuitpython).
 
-[2022####](https://github.com/adafruit/Adafruit_CircuitPython_Bundle/releases/latest) is the latest CircuitPython library bundle.
+[20221021](https://github.com/adafruit/Adafruit_CircuitPython_Bundle/releases/latest) is the latest CircuitPython library bundle.
 
-[v#.#.#](https://micropython.org/download) is the latest MicroPython release. Documentation for it is [here](http://docs.micropython.org/en/latest/pyboard/).
+[v1.19.1](https://micropython.org/download) is the latest MicroPython release. Documentation for it is [here](http://docs.micropython.org/en/latest/pyboard/).
 
-[#.#.#](https://www.python.org/downloads/) is the latest Python release. The latest pre-release version is [#.#.#](https://www.python.org/download/pre-releases/).
+[3.11.0](https://www.python.org/downloads/) is the latest Python release. The latest pre-release version is [3.12.0a0](https://www.python.org/download/pre-releases/).
 
 [#,### Stars](https://github.com/adafruit/circuitpython/stargazers) Like CircuitPython? [Star it on GitHub!](https://github.com/adafruit/circuitpython)
 


### PR DESCRIPTION
Python 3.11.0 is not quite out yet, but should be out by the time of the newsletter, so the Python version numbers are anticipated.