### PR TITLE
New/updated guides/libs

### DIFF
--- a/_drafts/2022-11-22-draft.md
+++ b/_drafts/2022-11-22-draft.md
@@ -5,7 +5,7 @@ date: 2022-11-08 07:00:00 -0800
 categories: weekly
 ---
 
-- [ ] Kattni updates
+- [X] Kattni updates
 - [ ] change date
 - [ ] update title
 - [ ] Feature story
@@ -205,15 +205,9 @@ Looking to add a new board to CircuitPython? It's highly encouraged! Adafruit ha
 
 [![New Learn Guides](../assets/20221122/20221122learn.jpg)](https://learn.adafruit.com/guides/latest)
 
-[title](url) from [name](url)
+[Adafruit PiCowbell Proto for Pico](https://learn.adafruit.com/picowbell-proto) from [Kattni](https://learn.adafruit.com/u/kattni)
 
-[title](url) from [name](url)
-
-[title](url) from [name](url)
-
-## Updated Learn Guides!
-
-[title](url) from [name](url)
+[Adafruit High Power Infrared LED Emitter](https://learn.adafruit.com/adafruit-high-power-infrared-led-emitter) from [Liz Clark](https://learn.adafruit.com/u/BlitzCityDIY)
 
 ## CircuitPython Libraries!
 
@@ -227,19 +221,13 @@ If you'd like to contribute, CircuitPython libraries are a great place to start.
 
 You can check out this [list of all the Adafruit CircuitPython libraries and drivers available](https://github.com/adafruit/Adafruit_CircuitPython_Bundle/blob/master/circuitpython_library_list.md). 
 
-The current number of CircuitPython libraries is **###**!
-
-**New Libraries!**
-
-Here's this week's new CircuitPython libraries:
-
-* [library](url)
+The current number of CircuitPython libraries is **393**!
 
 **Updated Libraries!**
 
 Here's this week's updated CircuitPython libraries:
 
-* [library](url)
+* There are too many updated libraries to list this week! To view the list, check out the [Library Report](https://adafruit-circuit-python.s3.amazonaws.com/adabot/bin/reports/circuitpython_library_report_20221122.txt).
 
 ## What’s the team up to this week?
 


### PR DESCRIPTION
Suggestion for Learn Guides image: https://cdn-shop.adafruit.com/970x728/5200-06.jpg

I put a broken link in for the "Updated Libraries" section, so it will link to the latest Library Report when the newsletter comes out on Tuesday, instead of today's.