### PR TITLE
Add info for The CircuitPython Show for Dec 13 2022

### DIFF
--- a/_drafts/2022-12-13-draft.md
+++ b/_drafts/2022-12-13-draft.md
@@ -83,7 +83,7 @@ Catch all the episodes in the [YouTube playlist](https://www.youtube.com/playlis
 
 The CircuitPython Show is an independent podcast hosted by Paul Cutler, focusing on the people doing awesome things with CircuitPython. Each episode features Paul in conversation with a guest for a short interview – [CircuitPythonShow](https://circuitpythonshow.com/) and [Twitter](https://twitter.com/circuitpyshow).
 
-The latest episode was released (date) and features (guest).  They and Paul talk {subject} – [Show List](https://circuitpythonshow.com/episodes/all).
+In the latest episode, Alec Delaney joines the show and shares how CircuitPython uses continuous integration for development and its benefits. – [Show List](https://circuitpythonshow.com/episodes/all).
 
 ## Project of the Week
 


### PR DESCRIPTION
Update episode info for The CircuitPython Show for the Dec 13th newsletter.

Thanks!

