### PR TITLE
Update info for The CircuitPython Show

### DIFF
--- a/_drafts/2022-12-20-draft.md
+++ b/_drafts/2022-12-20-draft.md
@@ -77,14 +77,6 @@ John Park’s CircuitPython Parsec this week is on {subject} - [Adafruit Blog](l
 
 Catch all the episodes in the [YouTube playlist](https://www.youtube.com/playlist?list=PLjF7R1fz_OOWFqZfqW9jlvQSIUmwn9lWr).
 
-### The CircuitPython Show
-
-[![The CircuitPython Show](../assets/20221220/cpshow.jpg)](https://circuitpythonshow.com/)
-
-The CircuitPython Show is an independent podcast hosted by Paul Cutler, focusing on the people doing awesome things with CircuitPython. Each episode features Paul in conversation with a guest for a short interview – [CircuitPythonShow](https://circuitpythonshow.com/) and [Twitter](https://twitter.com/circuitpyshow).
-
-The latest episode was released (date) and features (guest).  They and Paul talk {subject} – [Show List](https://circuitpythonshow.com/episodes/all).
-
 ## Project of the Week
 
 [![title](../assets/20221220/20221220-name.jpg)](url)

--- a/_drafts/template.md
+++ b/_drafts/template.md
@@ -79,14 +79,6 @@ John Park’s CircuitPython Parsec this week is on {subject} - [Adafruit Blog](l
 
 Catch all the episodes in the [YouTube playlist](https://www.youtube.com/playlist?list=PLjF7R1fz_OOWFqZfqW9jlvQSIUmwn9lWr).
 
-### The CircuitPython Show
-
-[![The CircuitPython Show](../assets/2022mmdd/cpshow.jpg)](https://circuitpythonshow.com/)
-
-The CircuitPython Show is an independent podcast hosted by Paul Cutler, focusing on the people doing awesome things with CircuitPython. Each episode features Paul in conversation with a guest for a short interview – [CircuitPythonShow](https://circuitpythonshow.com/) and [Twitter](https://twitter.com/circuitpyshow).
-
-The latest episode was released (date) and features (guest).  They and Paul talk {subject} – [Show List](https://circuitpythonshow.com/episodes/all).
-
 ## Project of the Week
 
 [![title](../assets/2022mmdd/2022mmdd-name.jpg)](url)

--- a/_drafts/template.md
+++ b/_drafts/template.md
@@ -79,6 +79,14 @@ John Park’s CircuitPython Parsec this week is on {subject} - [Adafruit Blog](l
 
 Catch all the episodes in the [YouTube playlist](https://www.youtube.com/playlist?list=PLjF7R1fz_OOWFqZfqW9jlvQSIUmwn9lWr).
 
+### The CircuitPython Show
+
+[![The CircuitPython Show](../assets/2022mmdd/cpshow.jpg)](https://circuitpythonshow.com/)
+
+The CircuitPython Show is an independent podcast hosted by Paul Cutler, focusing on the people doing awesome things with CircuitPython. Each episode features Paul in conversation with a guest for a short interview – [CircuitPythonShow](https://circuitpythonshow.com/) and [Twitter](https://twitter.com/circuitpyshow).
+
+The latest episode was released (date) and features (guest).  They and Paul talk {subject} – [Show List](https://circuitpythonshow.com/episodes/all).
+
 ## Project of the Week
 
 [![title](../assets/2022mmdd/2022mmdd-name.jpg)](url)


### PR DESCRIPTION
The show is going on a short hiatus over the holidays.  I removed mention of the show in the newsletter and template.  I will open a PR when the show returns.

Thanks!