### PR TITLE
add links to last week's CircuitPython meeting

### DIFF
--- a/_drafts/2023-02-28-draft.md
+++ b/_drafts/2023-02-28-draft.md
@@ -168,7 +168,9 @@ text - [site](url).
 
 PyDev of the Week: NAME on [Mouse vs Python]()
 
-CircuitPython Weekly Meeting for DATE ([notes]()) [on YouTube]()
+CircuitPython Weekly Meeting for February 21, 2023 ([notes](https://github.com/adafruit/adafruit-circuitpython-weekly-meeting/blob/main/2023/2023-02-21.md)) [on YouTube](https://youtu.be/qUmMJYkIrJk)
+CircuitPython Weekly Meeting for Feburary 27, 2023 ([notes]()) [on YouTube]()
+
 
 **#ICYDNCI What was the most popular, most clicked link, in [last week's newsletter](https://link)? [title](url).**
 


### PR DESCRIPTION
Today's meeting was after the publication of today's newsletter. Added links to Feb 21 meeting, and placeholder for Feb 27 meeting