### PR TITLE
20230522-weekly-meeting

### DIFF
--- a/_drafts/2023-05-23-draft.md
+++ b/_drafts/2023-05-23-draft.md
@@ -183,7 +183,7 @@ text - [site](url).
 
 text - [site](url).
 
-PyDev of the Week: NAME on [Mouse vs Python]()
+PyDev of the Week: Benjamin Bennett Alexander on [Mouse vs Python](https://www.blog.pythonlibrary.org/2023/05/22/pydev-of-the-week-benjamin-bennett-alexander/)
 
 CircuitPython Weekly Meeting for DATE ([notes]()) [on YouTube]()
 
@@ -334,15 +334,15 @@ If you know of virtual events or upcoming events, please let us know via email t
 
 ## Latest releases
 
-CircuitPython's stable release is [#.#.#](https://github.com/adafruit/circuitpython/releases/latest) and its unstable release is [#.#.#-##.#](https://github.com/adafruit/circuitpython/releases). New to CircuitPython? Start with our [Welcome to CircuitPython Guide](https://learn.adafruit.com/welcome-to-circuitpython).
+CircuitPython's stable release is [8.0.5](https://github.com/adafruit/circuitpython/releases/latest) and its unstable release is [8.1.0-RC.0](https://github.com/adafruit/circuitpython/releases). New to CircuitPython? Start with our [Welcome to CircuitPython Guide](https://learn.adafruit.com/welcome-to-circuitpython).
 
-[2023####](https://github.com/adafruit/Adafruit_CircuitPython_Bundle/releases/latest) is the latest CircuitPython library bundle.
+[20230522](https://github.com/adafruit/Adafruit_CircuitPython_Bundle/releases/latest) is the latest CircuitPython library bundle.
 
-[v#.#.#](https://micropython.org/download) is the latest MicroPython release. Documentation for it is [here](http://docs.micropython.org/en/latest/pyboard/).
+[v1.20.0](https://micropython.org/download) is the latest MicroPython release. Documentation for it is [here](http://docs.micropython.org/en/latest/pyboard/).
 
-[#.#.#](https://www.python.org/downloads/) is the latest Python release. The latest pre-release version is [#.#.#](https://www.python.org/download/pre-releases/).
+[3.11.3](https://www.python.org/downloads/) is the latest Python release. The latest pre-release version is [3.12.0a7](https://www.python.org/download/pre-releases/).
 
-[#,### Stars](https://github.com/adafruit/circuitpython/stargazers) Like CircuitPython? [Star it on GitHub!](https://github.com/adafruit/circuitpython)
+[3,538 Stars](https://github.com/adafruit/circuitpython/stargazers) Like CircuitPython? [Star it on GitHub!](https://github.com/adafruit/circuitpython)
 
 ## Call for help -- Translating CircuitPython is now easier than ever!
 

--- a/_drafts/2023-05-23-draft.md
+++ b/_drafts/2023-05-23-draft.md
@@ -185,7 +185,7 @@ text - [site](url).
 
 PyDev of the Week: Benjamin Bennett Alexander on [Mouse vs Python](https://www.blog.pythonlibrary.org/2023/05/22/pydev-of-the-week-benjamin-bennett-alexander/)
 
-CircuitPython Weekly Meeting for DATE ([notes]()) [on YouTube]()
+CircuitPython Weekly Meeting for DATE ([notes](https://github.com/adafruit/adafruit-circuitpython-weekly-meeting/blob/main/2023/2023-05-22.md)) [on YouTube](https://youtu.be/o1JjOeddlEc)
 
 #ICYDNCI What was the most popular, most clicked link, in [last week's newsletter](https://www.adafruitdaily.com/2023/05/16/python-on-microcontrollers-newsletter-400-circuitpython-compatible-boards-hackaday-supercon-and-much-more-circuitpython-python-micropython-thepsf-raspberry_pi/)? [FreakWAN](https://github.com/antirez/freakwan).
 


### PR DESCRIPTION
Here are the notes from the CircuitPython weekly meeting.  Just waiting for the final PR for the notes doc link, but the link should be correct.