### PR TITLE
Fix typos and update Quirkey

### DIFF
--- a/_drafts/2023-05-23-draft.md
+++ b/_drafts/2023-05-23-draft.md
@@ -91,9 +91,9 @@ The CircuitPython Show is an independent podcast hosted by Paul Cutler, focusing
 
 The latest episode was released Monday, May 22nd.  CircuitPython core developer Dan Halbert joins the show and he shares discovering CircuitPython, advice for new contributors, release management, and more  – [Show List](https://www.circuitpythonshow.com/@circuitpythonshow/episodes).
 
-## Project of the Week: Reviving the Assistive Technology Quirkey and Microwrier Keypads
+## Project of the Week: Reviving the Assistive Technology Quinkey and Microwriter Keypads
 
-[![Quirkey and Microwrier Keypads](../assets/20230523/20230523mw.jpg)](https://octodon.social/@vik@mastodon.nzoss.nz/110357839296190386)
+[![Quinkey and Microwriter Keypads](../assets/20230523/20230523mw.jpg)](https://octodon.social/@vik@mastodon.nzoss.nz/110357839296190386)
 
 Quirkey is CircuitPython code for the Pi Pico version of the Quirkey keyboard, based heavily on the work done by Microwriter. The device emulates a USB HID US keyboard and requires no specific driver. It does however need the Adafruit HID CircuitPython libraries which can be downloaded from Adafruit's HID example web page or from Github. It now includes a simple "typing tudor" application - [GitHub](https://github.com/VikOlliver/Quirkey) via [Mastodon](https://octodon.social/@vik@mastodon.nzoss.nz/110357839296190386).
 
@@ -131,7 +131,7 @@ An RP2040 / Raspberry Pi Pico based robot running CircuitPython for the [TABLEBo
 
 [![Traffic Light](../assets/20230523/20230523light.jpg)](https://twitter.com/NetEng_Ian/status/1656481391419457536)
 
-Making a traffioc light with LEDs, a Raspberry Pi Pico and CircuitPython - [Twitter](https://twitter.com/NetEng_Ian/status/1656481391419457536).
+Making a traffic light with LEDs, a Raspberry Pi Pico and CircuitPython - [Twitter](https://twitter.com/NetEng_Ian/status/1656481391419457536).
 
 [![DIY Circular Sequencer made with Raspberry Pico](../assets/20230523/20230523synth.jpg)](https://www.reddit.com/r/synthdiy/comments/nd14d4/diy_circular_sequencer_made_with_raspberry_pico/)
 


### PR DESCRIPTION
Hi Anne,

I noticed in prepping for the weekly meeting a couple of typos, which I fixed.  

I also updated the Quirkey section - clicking through the hardware appears to be the Quinkey and Quirkey is the CircuitPython software.