### PR TITLE
post meeting additions 5/30/23

### DIFF
--- a/_drafts/2023-06-06-draft.md
+++ b/_drafts/2023-06-06-draft.md
@@ -167,7 +167,9 @@ text - [site](url).
 
 PyDev of the Week: NAME on [Mouse vs Python]()
 
-CircuitPython Weekly Meeting for DATE ([notes]()) [on YouTube]()
+CircuitPython Weekly Meeting for 5/30/23 ([notes](https://github.com/adafruit/adafruit-circuitpython-weekly-meeting/blob/main/2023/2023-05-30.md)) [on YouTube](https://youtu.be/UUQlni5EGkE)
+
+CircuitPython Weekly Meeting for 6/5/23 ([notes]()) [on YouTube]()
 
 **#ICYDNCI What was the most popular, most clicked link, in [last week's newsletter](https://link)? [title](url).**
 


### PR DESCRIPTION
I duplicated the meeting line since we'll also have next weeks meeting before the next newsletter. I filled in the links for this weeks and put dates for both of them.

PyDev of the week, and the statistics will need to be added on Monday as normal next week. 

Let me know if there are any further changes needed at this time.