### PR TITLE
New/updated libs, UPDATED-only guide

### DIFF
--- a/_drafts/2023-06-06-draft.md
+++ b/_drafts/2023-06-06-draft.md
@@ -5,7 +5,7 @@ date: 2023-06-06 07:00:00 -0800
 categories: weekly
 ---
 
-- [ ] Kattni updates
+- [X] Kattni updates
 - [ ] change date
 - [ ] update title
 - [ ] Feature story
@@ -235,19 +235,11 @@ Looking to add a new board to CircuitPython? It's highly encouraged! Adafruit ha
 - [Adding a Single Board Computer to PlatformDetect for Blinka](https://learn.adafruit.com/adding-a-single-board-computer-to-platformdetect-for-blinka)
 - [Adding a Single Board Computer to Blinka](https://learn.adafruit.com/adding-a-single-board-computer-to-blinka)
 
-## New Learn Guides!
-
-[![New Learn Guides](../assets/20230606/20230606learn.jpg)](https://learn.adafruit.com/guides/latest)
-
-[title](url) from [name](url)
-
-[title](url) from [name](url)
-
-[title](url) from [name](url)
-
 ## Updated Learn Guides!
 
-[title](url) from [name](url)
+[![Updated Learn Guides](../assets/20230606/20230606learn.jpg)](https://learn.adafruit.com/guides/latest)
+
+[Building CircuitPython](https://learn.adafruit.com/building-circuitpython) from [Dan Halbert](https://learn.adafruit.com/u/danhalbert)
 
 ## CircuitPython Libraries!
 
@@ -261,21 +253,36 @@ If you'd like to contribute, CircuitPython libraries are a great place to start.
 
 You can check out this [list of all the Adafruit CircuitPython libraries and drivers available](https://github.com/adafruit/Adafruit_CircuitPython_Bundle/blob/master/circuitpython_library_list.md). 
 
-The current number of CircuitPython libraries is **###**!
+The current number of CircuitPython libraries is **441**!
 
 **New Libraries!**
 
 Here's this week's new CircuitPython libraries:
 
-* [library](url)
+  * [jposada202020/CircuitPython_DISPLAY_HT16K33](https://github.com/jposada202020/CircuitPython_DISPLAY_HT16K33)
 
 **Updated Libraries!**
 
 Here's this week's updated CircuitPython libraries:
+  * [adafruit/Adafruit_CircuitPython_HTTPServer](https://github.com/adafruit/Adafruit_CircuitPython_HTTPServer)
+  * [adafruit/Adafruit_CircuitPython_PCF8591](https://github.com/adafruit/Adafruit_CircuitPython_PCF8591)
+  * [adafruit/Adafruit_CircuitPython_Requests](https://github.com/adafruit/Adafruit_CircuitPython_Requests)
+  * [furbrain/CircuitPython_mag_cal](https://github.com/furbrain/CircuitPython_mag_cal)
 
-* [library](url)
-
-**Library Statistics**
+**Library PyPI Weekly Download Stats**
+* **Total Library Stats**
+  * 111186 PyPI downloads over 310 libraries
+* **Top 10 Libraries by PyPI Downloads**
+  * Adafruit CircuitPython BusDevice (adafruit-circuitpython-busdevice): 7692
+  * Adafruit CircuitPython Requests (adafruit-circuitpython-requests): 7429
+  * Adafruit CircuitPython Register (adafruit-circuitpython-register): 2121
+  * Adafruit CircuitPython NeoPixel (adafruit-circuitpython-neopixel): 1521
+  * Adafruit CircuitPython Motor (adafruit-circuitpython-motor): 1019
+  * Adafruit CircuitPython Pixelbuf (adafruit-circuitpython-pixelbuf): 879
+  * Adafruit CircuitPython Wiznet5k (adafruit-circuitpython-wiznet5k): 866
+  * Adafruit CircuitPython Display Text (adafruit-circuitpython-display-text): 865
+  * Adafruit CircuitPython BLE (adafruit-circuitpython-ble): 779
+  * Adafruit CircuitPython ADS1x15 (adafruit-circuitpython-ads1x15): 753
 
 
 


### PR DESCRIPTION
There was only one guide this week, and it's not new, it's updated. So I removed all of the new guide text, and moved the image link below the "Updated Learn Guides" header so there's still an image to go with it.