### PR TITLE
Add GitHub link for CircuitPython Parsec

### DIFF
--- a/_drafts/2023-07-24-draft.md
+++ b/_drafts/2023-07-24-draft.md
@@ -88,7 +88,7 @@ You can see the latest video and past videos on the Adafruit YouTube channel und
 
 [![CircuitPython Parsec](../assets/20230724/20230724jp.jpg)](link)
 
-John Park’s CircuitPython Parsec this week is on {subject} - [Adafruit Blog](link), [GitHub](https://github.com/jedgarpark/parsec) and [YouTube](link).
+John Park’s CircuitPython Parsec this week is on {subject} - [Adafruit Blog](link), [GitHub](https://github.com/jedgarpark/parsec), and [YouTube](link).
 
 Catch all the episodes in the [YouTube playlist](https://www.youtube.com/playlist?list=PLjF7R1fz_OOWFqZfqW9jlvQSIUmwn9lWr).
 

--- a/_drafts/2023-07-24-draft.md
+++ b/_drafts/2023-07-24-draft.md
@@ -88,7 +88,7 @@ You can see the latest video and past videos on the Adafruit YouTube channel und
 
 [![CircuitPython Parsec](../assets/20230724/20230724jp.jpg)](link)
 
-John Park’s CircuitPython Parsec this week is on {subject} - [Adafruit Blog](link) and [YouTube](link).
+John Park’s CircuitPython Parsec this week is on {subject} - [Adafruit Blog](link), [GitHub](https://github.com/jedgarpark/parsec) and [YouTube](link).
 
 Catch all the episodes in the [YouTube playlist](https://www.youtube.com/playlist?list=PLjF7R1fz_OOWFqZfqW9jlvQSIUmwn9lWr).
 


### PR DESCRIPTION
Now that JP is publishing the code each week used in his CircuitPython Parsec show, I would like to propose including a link to the repo in the newsletter.

It could be just to the repo or to that week's specific code example, but that's up to the editor if they want that extra step.

This PR just adds a link to the repository along with the blog post and YouTube link.