### PR TITLE
meeting 8/21/23

### DIFF
--- a/_drafts/2023-08-28-draft.md
+++ b/_drafts/2023-08-28-draft.md
@@ -165,9 +165,7 @@ text - [site](url).
 
 text - [site](url).
 
-PyDev of the Week: NAME on [Mouse vs Python]().
-
-CircuitPython Weekly Meeting for DATE ([notes]()) [on YouTube]().
+CircuitPython Weekly Meeting for August 21, 2023 ([notes](https://github.com/adafruit/adafruit-circuitpython-weekly-meeting/blob/main/2023/2023-08-21.md)) [on YouTube](https://youtu.be/Djc2nLD7uSs).
 
 **#ICYDNCI What was the most popular, most clicked link, in [last week's newsletter](https://link)? [title](url).**
 


### PR DESCRIPTION
I removed PyDev of the week for this one because there isn't a new developer since 8/7 https://www.blog.pythonlibrary.org/category/pydevoftheweek/. Zac Hatfield Dodds was already included in a newsletter.

Let me know if I should do anything differently though, I'm happy to change if there is a better way to handle.