### PR TITLE
Add meeting notes link and YouTube link.  

### DIFF
--- a/_drafts/2023-09-04-draft.md
+++ b/_drafts/2023-09-04-draft.md
@@ -167,7 +167,7 @@ text - [site](url).
 
 PyDev of the Week: NAME on [Mouse vs Python]().
 
-CircuitPython Weekly Meeting for DATE ([notes]()) [on YouTube]().
+CircuitPython Weekly Meeting for August 28, 2023 ([notes](https://github.com/adafruit/adafruit-circuitpython-weekly-meeting/blob/main/2023/2023-08-28.md)) [on YouTube](https://youtu.be/UndmYxxiNZQ).
 
 **#ICYDNCI What was the most popular, most clicked link, in [last week's newsletter](https://link)? [title](url).**
 


### PR DESCRIPTION
No PyDev of the Week in the last 3 weeks, but I did not delete the line from the newsletter.  Meeting notes and YouTube link added.

Thanks!