### PR TITLE
Add The CircuitPython Show notes for 1/15 episode and newsletter

### DIFF
--- a/_drafts/2024-01-15-draft.md
+++ b/_drafts/2024-01-15-draft.md
@@ -103,6 +103,13 @@ John Park’s CircuitPython Parsec this week is on {subject} - [Adafruit Blog](l
 
 Catch all the episodes in the [YouTube playlist](https://www.youtube.com/playlist?list=PLjF7R1fz_OOWFqZfqW9jlvQSIUmwn9lWr).
 
+[![The CircuitPython Show](../assets/20231120/cpshow.jpg)](url)
+
+The CircuitPython Show is an independent podcast hosted by Paul Cutler, focusing on the people doing awesome things with CircuitPython. Each episode features Paul in conversation with a guest for a short interview – [CircuitPython Show](https://www.circuitpythonshow.com/).
+
+The latest episode was released January 15th and features CircuitPython core developer Jeff Epler.  Jeff discusses his role as a core developer, adding jpegio support to CircuitPython, and the recent addition of over 2000 new fonts to CircuitPython.
+
+
 **CircuitPython Weekly Meeting**
 
 CircuitPython Weekly Meeting for January 8, 2024 ([notes](https://github.com/adafruit/adafruit-circuitpython-weekly-meeting/blob/main/2024/2024-01-08.md)) [on YouTube](https://youtu.be/BoUmvQuKYLw)


### PR DESCRIPTION
Update newsletter with notes for the 1/15 episode of The CircuitPython Show.

Thank you!