### PR TITLE
Update 2024-09-16-draft.md

### DIFF
--- a/_drafts/2024-09-16-draft.md
+++ b/_drafts/2024-09-16-draft.md
@@ -15,7 +15,7 @@ We're on [Discord](https://discord.gg/HYqvREz), [Twitter](https://twitter.com/se
 
 [![CircuitPython Comes to the ESP32-P4 Evaluation Board](../assets/20240916/20240916p4.jpg)](https://www.youtube.com/watch?v=ykGEw1Hig0Q&t=2s)
 
-Core CircuitPython developer Scott has been chugging away at adding ESP32-P4 support to CircuitPython. He has provided Ladyada a bin file that runs on the Eval board received last week from Espressif. Native USB is still in progress, but she could connect to the REPL and save files using the USB-Serial converter. "It's so fast at 400mhz, and with 16 or 32 MHz of PSRAM, it's going to be an awesome board for embedded Python" - [Adafruit Blog](https://blog.adafruit.com/2024/09/10/esp32-p4-booting-up-and-running-circuitpython/) and [YouTube](https://www.youtube.com/watch?v=ykGEw1Hig0Q&t=2s).
+Core CircuitPython developer Scott has been chugging away at adding ESP32-P4 support to CircuitPython. He has provided Ladyada a bin file that runs on the Eval board received last week from Espressif. Native USB is still in progress, but she could connect to the REPL and save files using the USB-Serial converter. "It's so fast at 400mhz, and with 16 or 32 MB of PSRAM, it's going to be an awesome board for embedded Python" - [Adafruit Blog](https://blog.adafruit.com/2024/09/10/esp32-p4-booting-up-and-running-circuitpython/) and [YouTube](https://www.youtube.com/watch?v=ykGEw1Hig0Q&t=2s).
 
 ## Armulet allows Raspberry Pi to run Arm code on RISC-V
 


### PR DESCRIPTION
correct specs to "supports up to 32 MB PSRAM"  per

https://docs.espressif.com/projects/esp-dev-kits/en/latest/esp32p4/esp32-p4-function-ev-board/index.html

I tried to communicate this over discord - but just found the github page - which might have been the correct place to report the correction