### PR TITLE
Add episode info for The CircuitPython Show for March 25th

### DIFF
--- a/_drafts/2025-03-24-draft.md
+++ b/_drafts/2025-03-24-draft.md
@@ -100,7 +100,7 @@ Catch all the episodes in the [YouTube playlist](https://www.youtube.com/playlis
 
 [![The CircuitPython Show](../assets/20250324/cpshow.jpg)](https://www.circuitpythonshow.com)
 
-The CircuitPython Show has returned after a one year hiatus! In the latest episode, host Paul Cutler interviews xxxx - [The CircuitPython Show](https://www.circuitpythonshow.com)
+In the latest episode released March 24th, Liz Clark and Noe Ruiz join the show and share how they collaborate on projects and share some of their favorite collabs. - [The CircuitPython Show](https://www.circuitpythonshow.com/@circuitpythonshow)
 
 **CircuitPython Weekly Meeting**
 


### PR DESCRIPTION
This PR adds information about the latest episode of The CircuitPython Show for March 25th.  Thank you!