### PR TITLE
Update draft with CircuitPython 10.1.0 Beta 1 details

### DIFF
--- a/_drafts/2025-11-10-draft.md
+++ b/_drafts/2025-11-10-draft.md
@@ -45,11 +45,15 @@ We're on [Discord](https://discord.gg/HYqvREz), [Twitter/X](https://twitter.com/
 
 text - [site](url).
 
-## Feature
+## CircuitPython 10.1.0 Beta 1 Released
 
-[![title](../assets/20251110/20251110-name.jpg)](url)
+[![CircuitPython 10.1.0 Beta 1 Released](../assets/20251110/20251110cp10.jpg)](https://blog.adafruit.com/2025/11/06/circuitpython-10-1-0-beta-1-released/)
 
-text - [site](url).
+CircuitPython 10.1.0-beta.1 is the latest beta release for 10.1.0. It has known bugs that will be fixed before the final release of 10.1.0 - [Adafruit Blog](https://blog.adafruit.com/2025/11/06/circuitpython-10-1-0-beta-1-released/) and release notes - [GitHub](https://github.com/adafruit/circuitpython/releases/tag/10.1.0-beta.1).
+
+**Highlights of this release**
+* Add `mipidsi` module to support MIPI DSI displays. Currently enabled for ESP32-P4.
+* Fix problems with presenting user-mounted SD cards over USB.
 
 ## New Version of VSCode Extension "CircuitPython Sync" Adds Serial Port Support
 


### PR DESCRIPTION
Added details about CircuitPython 10.1.0 Beta 1 release including highlights and links to the Adafruit blog and GitHub release notes.