### PR TITLE
add meeting 1/12/26

### DIFF
--- a/_drafts/2026-01-19-draft.md
+++ b/_drafts/2026-01-19-draft.md
@@ -454,7 +454,7 @@ Catch all the episodes in the [YouTube playlist](https://www.youtube.com/playlis
 
 **CircuitPython Weekly Meeting**
 
-CircuitPython Weekly Meeting for {date} ([notes](file)) [on YouTube](link).
+CircuitPython Weekly Meeting for January 12, 2026 ([notes](https://github.com/adafruit/adafruit-circuitpython-weekly-meeting/blob/main/2026/2026-01-12.md)) [on YouTube](https://www.youtube.com/watch?v=BUlKL_s_6e8).
 
 ## Project of the Week
 


### PR DESCRIPTION
It looks like the `2026-01-19-draft.md` file contains a copy of the compiled HTML from the 1/12/26 newsletter before the markdown content for the 1/19/26 newsletter.

I updated the meeting link in the markdown section and did not touch the HTML section.