### PR TITLE
Fix date and links for CircuitPython Weekly Meeting

### DIFF
--- a/_drafts/2026-02-09-draft.md
+++ b/_drafts/2026-02-09-draft.md
@@ -103,7 +103,7 @@ Catch all the episodes in the [YouTube playlist](https://www.youtube.com/playlis
 
 **CircuitPython Weekly Meeting**
 
-CircuitPython Weekly Meeting for {date} ([notes](file)) [on YouTube](link).
+CircuitPython Weekly Meeting for February 2nd, 2026 ([notes](https://github.com/adafruit/adafruit-circuitpython-weekly-meeting/blob/main/2026/2026-02-02.md)) [on YouTube](https://youtu.be/3b7ZhhTR6NY).
 
 ## Project of the Week
 


### PR DESCRIPTION
Updated the CircuitPython Weekly Meeting entry with the correct date and links.